### PR TITLE
[codex] Replace control HUD with destination-driven navigation UI

### DIFF
--- a/docs/ARCHITECTURE/technicaldecisions/014-destination-driven-navigation-hud.md
+++ b/docs/ARCHITECTURE/technicaldecisions/014-destination-driven-navigation-hud.md
@@ -1,0 +1,132 @@
+# ADR 014: Destination-driven navigation HUD for autonomous travel
+
+- **Status:** Accepted
+- **Date:** 2026-03-30
+- **Related:** ADR 005 (shift normal play to autonomous space trucking), ADR 008 (minimal HUD using Tailwind CSS v4 and shadcn-style components), ADR 011 (destination catalog, moon ephemerides, transfer planning, and autonomous guidance), ADR 013 (command-driven autonomous guidance for normal-play ship control)
+
+## Context
+
+The autonomous-travel work is now in place:
+
+- the player can choose destinations from the destination catalog
+- the transfer planner produces live route and intercept data
+- the flight computer continuously steers and thrusts without manual piloting
+
+Even with that architecture in place, the main HUD still reads like a generic
+telemetry overlay with a secondary route-control form. That creates a mismatch
+between the intended game loop and the actual interface:
+
+- destination selection is present, but it is not visually the center of the
+  normal-play experience
+- planner status and autonomous-guidance state are available, but they are not
+  explained as the ship's current travel mode
+- time controls exist, but they are not framed as part of supervising an
+  autonomous trip
+
+Issue #27 requires the main HUD to stop feeling like a leftover manual-flight
+panel and instead feel like the bridge interface for destination-driven freight
+operations.
+
+## Decision
+
+### 1. The primary HUD flow becomes destination first, travel state second
+
+The first normal-play question the HUD answers is "where is the freighter going
+now?" The second is "how is the flight computer handling that trip?"
+
+That means the main HUD should foreground:
+
+- the current destination
+- a dropdown-style destination selector
+- immediate confirmation that changing destinations reroutes the ship live
+
+Destination selection is no longer a secondary control surface. It is the main
+player command in normal play.
+
+### 2. The destination panel must summarize the selected destination clearly
+
+Selecting a destination should immediately surface enough context for the
+player to understand what they picked without reading code or memorizing IDs.
+
+The destination summary should include:
+
+- destination name
+- destination type (planet, moon, colony, station, and so on)
+- its larger network or parent context when relevant
+
+This keeps the autonomous-travel loop legible even as the catalog grows to
+include mixed body, colony, and station entries.
+
+### 3. Travel status must expose both planner mode and autonomous state
+
+The HUD should explicitly distinguish between:
+
+- **planner status**: whether the route is using the current position, a future
+  intercept, or a fallback solution
+- **autonomous state**: whether the ship is acquiring course, cruising,
+  braking, or holding arrival
+
+The player should also see the trip details that explain those states:
+
+- current range
+- planned range
+- bearing
+- ETA
+- intercept window when one exists
+- how far the target is expected to move during the planned intercept
+
+These details let the UI explain autonomous travel without reintroducing manual
+piloting hints.
+
+### 4. Time controls remain part of travel supervision
+
+Time controls stay in the main HUD, but they should be framed as simulation and
+voyage supervision rather than as disconnected utility buttons.
+
+The HUD should show:
+
+- the current simulation date
+- whether time is paused or advancing
+- the active warp rate
+- direct slower / pause-or-resume / faster controls
+
+This keeps time management coherent with the new "set destination, monitor
+travel, adjust simulation pace" interaction model.
+
+### 5. Manual-orient and manual-flight affordances stay out of normal play
+
+The main HUD must not reintroduce:
+
+- keyboard flight hints
+- orient-to-target prompts
+- copy that implies the player should hand-fly the ship continuously
+
+Developer or legacy controls may still exist outside the player-facing normal
+HUD, but they are not part of the default experience.
+
+## Consequences
+
+### Positive
+
+- The interface finally matches the autonomous-travel ADRs instead of only
+  satisfying them in the simulation layer.
+- Destination changes become legible, confident actions rather than a hidden
+  dropdown behind generic telemetry.
+- Planner and guidance state become understandable to players without exposing
+  low-level physics controls.
+
+### Negative
+
+- The HUD now depends on a slightly richer metrics contract because the travel
+  panel needs autonomous state and intercept facts, not just raw distance and
+  speed.
+- More destination context on the HUD increases the amount of text that must
+  stay balanced against the canvas on smaller screens.
+
+## Follow-up
+
+- If cargo jobs or delivery schedules are added later, extend the same
+  destination-first layout with contract context rather than creating a
+  separate control HUD.
+- If manual/debug flight tools are kept for development, expose them in a
+  clearly separate debug surface so normal-play UX stays destination-driven.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,7 @@ export function AppShell({ SceneComponent = SimulatorCanvas }: AppShellProps) {
                 OrbitalTrucker
               </p>
               <h1 className="mt-1 text-lg font-semibold tracking-tight text-slate-50">
-                Autonomous bridge HUD
+                Destination bridge
               </h1>
             </div>
             <span className="rounded-full border border-cyan-400/15 bg-cyan-400/10 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-cyan-100/90">
@@ -109,14 +109,13 @@ export function AppShell({ SceneComponent = SimulatorCanvas }: AppShellProps) {
             </span>
           </div>
           <p className="mt-2 text-sm leading-6 text-slate-300">
-            Route selection, live planner telemetry, and time management stay
-            in reach while the freighter updates course on its own.
+            Select destinations, watch intercept and travel state, and manage
+            simulation time while the freighter reroutes on its own.
           </p>
         </Card>
 
         <MetricsPanel
           metrics={metrics}
-          selectedLocationName={selectedLocation.name}
           timeWarpDaysPerSecond={
             timePaused ? 0 : TIME_WARP_STEPS[timeWarpIndex]
           }
@@ -137,8 +136,12 @@ export function AppShell({ SceneComponent = SimulatorCanvas }: AppShellProps) {
 
         <ControlPanel
           destinations={destinations}
+          metrics={metrics}
           onSelectLocation={setSelectedLocationId}
           selectedLocationId={selectedLocation.id}
+          timeWarpDaysPerSecond={
+            timePaused ? 0 : TIME_WARP_STEPS[timeWarpIndex]
+          }
         />
 
         <LegendPanel bodies={legendBodies} />

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,4 +1,10 @@
 import {
+  formatAutonomousPhase,
+  formatTimeWarp,
+  formatTransferPlannerStatus,
+} from '../simulation/formatters'
+import type { SimulationMetrics } from '../simulation/types'
+import {
   formatLocationKind,
   getLocationParent,
   type LocationDefinition,
@@ -7,13 +13,17 @@ import { Card } from './ui/card'
 
 type ControlPanelProps = {
   destinations: readonly LocationDefinition[]
+  metrics: SimulationMetrics
   selectedLocationId: string
+  timeWarpDaysPerSecond: number
   onSelectLocation: (locationId: string) => void
 }
 
 export function ControlPanel({
   destinations,
+  metrics,
   selectedLocationId,
+  timeWarpDaysPerSecond,
   onSelectLocation,
 }: ControlPanelProps) {
   const selectedLocation =
@@ -28,24 +38,29 @@ export function ControlPanel({
     <Card className="pointer-events-auto border-white/10 bg-slate-950/55 p-4 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-xl">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-sm font-semibold tracking-tight text-slate-50">
-          Route control
+          Navigation
         </h2>
         <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-slate-400">
-          autonomous
+          live route
         </span>
       </div>
 
       <div className="mt-3 rounded-2xl border border-cyan-300/15 bg-cyan-400/10 px-3 py-3">
         <p className="text-xs font-medium uppercase tracking-[0.22em] text-cyan-100/85">
-          Flight computer engaged
+          Destination-driven bridge
         </p>
         <p className="mt-2 text-sm leading-6 text-slate-200">
-          Choose a destination and the freighter will keep reacquiring its
-          planner course as the system moves.
+          Choose a destination and the freighter will retarget, reacquire
+          course, and keep updating the trip plan as the system moves.
         </p>
         <div className="mt-3 flex flex-wrap gap-2">
-          <StatusPill label="[ / ] Time warp" />
-          <StatusPill label="Destination changes reroute live" />
+          <StatusPill
+            label={`Autonomy: ${formatAutonomousPhase(metrics.autonomousPhase)}`}
+          />
+          <StatusPill
+            label={`Planner: ${formatTransferPlannerStatus(metrics.plannerStatus)}`}
+          />
+          <StatusPill label={`Sim: ${formatTimeWarp(timeWarpDaysPerSecond)}`} />
         </div>
       </div>
 
@@ -54,10 +69,10 @@ export function ControlPanel({
           className="text-[10px] font-medium uppercase tracking-[0.22em] text-slate-400"
           htmlFor="destination-select"
         >
-          Destination
+          Current destination
         </label>
         <select
-          className="mt-2 w-full rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-slate-50 outline-none transition focus:border-cyan-300/60 focus:ring-2 focus:ring-cyan-300/20"
+          className="mt-2 w-full rounded-2xl border border-cyan-300/20 bg-white/[0.05] px-3 py-2.5 text-sm text-slate-50 outline-none transition focus:border-cyan-300/60 focus:ring-2 focus:ring-cyan-300/20"
           data-testid="destination-select"
           id="destination-select"
           onChange={(event) => {
@@ -77,13 +92,22 @@ export function ControlPanel({
         </select>
 
         {selectedLocation ? (
-          <div className="mt-3 rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2">
-            <p className="text-sm font-medium text-slate-50">
+          <div className="mt-3 rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-3">
+            <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-slate-400">
+              Destination summary
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-50">
               {selectedLocation.name}
             </p>
             <p className="mt-1 text-xs leading-5 text-slate-300">
+              {selectedLocation.group} ·{' '}
               {formatLocationKind(selectedLocation.kind)}
               {selectedParent ? ` · Parent: ${selectedParent.name}` : ''}
+            </p>
+            <p className="mt-2 text-xs leading-5 text-slate-400">
+              Destination changes apply immediately and the flight computer will
+              transition between course acquisition, cruise, braking, and
+              arrival without manual steering prompts.
             </p>
           </div>
         ) : null}

--- a/src/components/MetricsPanel.tsx
+++ b/src/components/MetricsPanel.tsx
@@ -1,5 +1,7 @@
 import {
+  formatAutonomousPhase,
   formatDistanceAu,
+  formatDurationSeconds,
   formatEtaDays,
   formatShipSpeedKmPerSecond,
   formatTimeWarp,
@@ -12,7 +14,6 @@ import { Card } from './ui/card'
 
 type MetricsPanelProps = {
   metrics: SimulationMetrics
-  selectedLocationName: string
   timeWarpDaysPerSecond: number
   onSlowerTime: () => void
   onPauseToggle: () => void
@@ -21,17 +22,19 @@ type MetricsPanelProps = {
 
 export function MetricsPanel({
   metrics,
-  selectedLocationName,
   timeWarpDaysPerSecond,
   onSlowerTime,
   onPauseToggle,
   onFasterTime,
 }: MetricsPanelProps) {
+  const pauseButtonLabel =
+    timeWarpDaysPerSecond === 0 ? 'Resume sim' : 'Pause sim'
+
   return (
     <Card className="pointer-events-auto border-white/10 bg-slate-950/55 p-4 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-xl">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-sm font-semibold tracking-tight text-slate-50">
-          Telemetry
+          Travel status
         </h2>
         <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-slate-400">
           live
@@ -40,12 +43,19 @@ export function MetricsPanel({
 
       <div className="mt-3 grid grid-cols-2 gap-2">
         <MetricCell
-          label="Simulated date"
-          value={formatUtcDate(metrics.simulatedDate)}
+          className="col-span-2"
+          label="Autonomous state"
+          value={formatAutonomousPhase(metrics.autonomousPhase)}
         />
         <MetricCell
-          label="Time warp"
-          value={formatTimeWarp(timeWarpDaysPerSecond)}
+          label="Planner status"
+          value={formatTransferPlannerStatus(metrics.plannerStatus)}
+        />
+        <MetricCell label="ETA" value={formatEtaDays(metrics.etaDays)} />
+        <MetricCell
+          className="col-span-2"
+          label="Simulated date"
+          value={formatUtcDate(metrics.simulatedDate)}
         />
         <MetricCell
           label="Ship speed"
@@ -55,13 +65,8 @@ export function MetricsPanel({
           label="Heliocentric radius"
           value={formatDistanceAu(metrics.heliocentricDistanceAu)}
         />
-        <MetricCell label="Destination" value={selectedLocationName} />
         <MetricCell
-          label="Planner"
-          value={formatTransferPlannerStatus(metrics.plannerStatus)}
-        />
-        <MetricCell
-          label="Target range"
+          label="Current range"
           value={formatDistanceAu(metrics.currentTargetDistanceAu)}
         />
         <MetricCell
@@ -69,35 +74,66 @@ export function MetricsPanel({
           value={formatDistanceAu(metrics.plannedDistanceAu)}
         />
         <MetricCell
+          label="Intercept window"
+          value={formatDurationSeconds(metrics.interceptTimeSeconds)}
+        />
+        <MetricCell
+          label="Target drift"
+          value={formatDistanceAu(metrics.targetMotionDuringInterceptAu)}
+        />
+        <MetricCell
           label="Bearing"
           value={`${metrics.targetBearingDeg.toFixed(1)}°`}
         />
-        <MetricCell label="ETA" value={formatEtaDays(metrics.etaDays)} />
       </div>
 
-      <div className="mt-3 grid grid-cols-3 gap-2">
-        <Button onClick={onSlowerTime} size="sm" variant="secondary">
-          Slower time
-        </Button>
-        <Button onClick={onPauseToggle} size="sm" variant="secondary">
-          Pause / resume
-        </Button>
-        <Button onClick={onFasterTime} size="sm" variant="secondary">
-          Faster time
-        </Button>
+      <div className="mt-3 rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-slate-400">
+              Simulation rate
+            </p>
+            <p className="mt-1 text-sm font-medium text-slate-50">
+              {formatTimeWarp(timeWarpDaysPerSecond)}
+            </p>
+          </div>
+          <p className="max-w-32 text-right text-xs leading-5 text-slate-400">
+            Adjust sim speed without breaking the autonomous travel loop.
+          </p>
+        </div>
+
+        <div className="mt-3 grid grid-cols-3 gap-2">
+          <Button onClick={onSlowerTime} size="sm" variant="secondary">
+            Slower
+          </Button>
+          <Button onClick={onPauseToggle} size="sm" variant="secondary">
+            {pauseButtonLabel}
+          </Button>
+          <Button onClick={onFasterTime} size="sm" variant="secondary">
+            Faster
+          </Button>
+        </div>
       </div>
     </Card>
   )
 }
 
 type MetricCellProps = {
+  className?: string
   label: string
   value: string
 }
 
-function MetricCell({ label, value }: MetricCellProps) {
+function MetricCell({ className, label, value }: MetricCellProps) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2">
+    <div
+      className={[
+        'rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
       <span className="block text-[10px] font-medium uppercase tracking-[0.2em] text-slate-400">
         {label}
       </span>

--- a/src/components/SimulatorCanvas.tsx
+++ b/src/components/SimulatorCanvas.tsx
@@ -58,7 +58,7 @@ function SceneContents({
   // already-advanced simulated date each frame.
   const { bodyMeshRefs, bodyPositionsRef } = useBodyPositions(simulatedDateRef)
 
-  const { plannerResultRef } = useAutonomousGuidance({
+  const { guidanceResultRef, plannerResultRef } = useAutonomousGuidance({
     controlInputRef,
     selectedLocationIdRef,
     shipStateRef,
@@ -105,6 +105,7 @@ function SceneContents({
       shipState.position,
       shipState.velocity,
       plan,
+      guidanceResultRef.current,
     )
   })
 

--- a/src/hooks/useSimulationMetrics.ts
+++ b/src/hooks/useSimulationMetrics.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import { Vector3 } from 'three'
 
 import { ASTRONOMICAL_UNIT_KM } from '../solar-data'
+import type { AutonomousGuidanceResult } from '../simulation/autonomous-guidance'
 import type { TransferPlannerResult } from '../simulation/transfer-planner'
 import type { SimulationMetrics } from '../simulation/types'
 
@@ -18,6 +19,7 @@ export function useSimulationMetrics(
     shipPosition: Vector3,
     velocity: Vector3,
     plannerResult: TransferPlannerResult,
+    guidanceResult: AutonomousGuidanceResult,
   ) => void
 } {
   const accumulatorRef = useRef(0)
@@ -34,6 +36,7 @@ export function useSimulationMetrics(
       shipPosition: Vector3,
       velocity: Vector3,
       plannerResult: TransferPlannerResult,
+      guidanceResult: AutonomousGuidanceResult,
     ) => {
       accumulatorRef.current += deltaSec
 
@@ -46,8 +49,12 @@ export function useSimulationMetrics(
           currentTargetDistanceAu: plannerResult.travel.currentDistanceAu,
           plannedDistanceAu: plannerResult.travel.plannedDistanceAu,
           plannerStatus: plannerResult.status,
+          autonomousPhase: guidanceResult.phase,
           targetBearingDeg: plannerResult.guidance.bearingAngleDeg,
           etaDays: plannerResult.travel.etaDays,
+          interceptTimeSeconds: plannerResult.travel.interceptTimeSeconds,
+          targetMotionDuringInterceptAu:
+            plannerResult.travel.targetMotionDuringInterceptAu,
         })
       }
     },

--- a/src/simulation/formatters.ts
+++ b/src/simulation/formatters.ts
@@ -1,4 +1,5 @@
 import { ASTRONOMICAL_UNIT_KM } from '../solar-data'
+import type { AutonomousGuidancePhase } from './autonomous-guidance'
 import type { TransferPlannerStatus } from './transfer-planner'
 
 export function formatDistanceAu(distanceAu: number): string {
@@ -47,6 +48,45 @@ export function formatEtaDays(etaDays: number | null): string {
   }
 
   return `${(etaDays / 365.25).toFixed(1)} yr`
+}
+
+export function formatDurationSeconds(durationSeconds: number | null): string {
+  if (durationSeconds === null) {
+    return '—'
+  }
+
+  if (durationSeconds < 60) {
+    return `${durationSeconds.toFixed(0)} s`
+  }
+
+  if (durationSeconds < 3_600) {
+    return `${(durationSeconds / 60).toFixed(0)} min`
+  }
+
+  const durationDays = durationSeconds / 86_400
+
+  if (durationDays < 1) {
+    return `${(durationSeconds / 3_600).toFixed(1)} h`
+  }
+
+  if (durationDays < 365.25) {
+    return `${durationDays.toFixed(1)} d`
+  }
+
+  return `${(durationDays / 365.25).toFixed(1)} yr`
+}
+
+export function formatAutonomousPhase(phase: AutonomousGuidancePhase): string {
+  switch (phase) {
+    case 'acquiring':
+      return 'Acquiring course'
+    case 'cruising':
+      return 'Cruising'
+    case 'braking':
+      return 'Braking'
+    case 'arrived':
+      return 'Arrived'
+  }
 }
 
 export function formatTransferPlannerStatus(

--- a/src/simulation/types.ts
+++ b/src/simulation/types.ts
@@ -1,3 +1,4 @@
+import type { AutonomousGuidancePhase } from './autonomous-guidance'
 import type { TransferPlannerStatus } from './transfer-planner'
 
 export type SimulationMetrics = {
@@ -9,10 +10,15 @@ export type SimulationMetrics = {
   /** Distance to the planner's current aim point. */
   plannedDistanceAu: number
   plannerStatus: TransferPlannerStatus
+  autonomousPhase: AutonomousGuidancePhase
   /** Angle in degrees between the ship's forward heading and the planner aim point. */
   targetBearingDeg: number
   /** Estimated travel time in days to the planner's current aim point. */
   etaDays: number | null
+  /** Planned time-to-intercept for the current route solution. */
+  interceptTimeSeconds: number | null
+  /** Expected destination motion between the current fix and intercept aim point. */
+  targetMotionDuringInterceptAu: number
 }
 
 export const TIME_WARP_STEPS = [0, 1 / 48, 1 / 12, 0.25, 1, 7, 30, 90] as const
@@ -26,6 +32,9 @@ export const INITIAL_METRICS: SimulationMetrics = {
   currentTargetDistanceAu: 0,
   plannedDistanceAu: 0,
   plannerStatus: 'current-position',
+  autonomousPhase: 'arrived',
   targetBearingDeg: 0,
   etaDays: null,
+  interceptTimeSeconds: null,
+  targetMotionDuringInterceptAu: 0,
 }

--- a/tests/component/ControlPanel.test.tsx
+++ b/tests/component/ControlPanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ControlPanel } from '../../src/components/ControlPanel'
+import { INITIAL_METRICS } from '../../src/simulation/types'
 import { getLocationCatalog } from '../../src/world/locations'
 
 describe('ControlPanel', () => {
@@ -11,12 +12,18 @@ describe('ControlPanel', () => {
     render(
       <ControlPanel
         destinations={getLocationCatalog()}
+        metrics={{
+          ...INITIAL_METRICS,
+          autonomousPhase: 'cruising',
+          plannerStatus: 'future-intercept',
+        }}
         onSelectLocation={onSelectLocation}
         selectedLocationId="earth"
+        timeWarpDaysPerSecond={0.25}
       />,
     )
 
-    fireEvent.change(screen.getByLabelText('Destination'), {
+    fireEvent.change(screen.getByLabelText('Current destination'), {
       target: { value: 'mars-high-port' },
     })
 
@@ -28,14 +35,19 @@ describe('ControlPanel', () => {
     render(
       <ControlPanel
         destinations={getLocationCatalog()}
+        metrics={{
+          ...INITIAL_METRICS,
+          autonomousPhase: 'acquiring',
+          plannerStatus: 'future-intercept',
+        }}
         onSelectLocation={vi.fn()}
         selectedLocationId="earth"
+        timeWarpDaysPerSecond={0.25}
       />,
     )
 
-    expect(screen.getByText('Flight computer engaged')).toBeInTheDocument()
-    expect(
-      screen.getByText('Destination changes reroute live'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('Destination-driven bridge')).toBeInTheDocument()
+    expect(screen.getByText('Autonomy: Acquiring course')).toBeInTheDocument()
+    expect(screen.getByText('Planner: Future intercept')).toBeInTheDocument()
   })
 })

--- a/tests/component/MetricsPanel.test.tsx
+++ b/tests/component/MetricsPanel.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MetricsPanel } from '../../src/components/MetricsPanel'
+import type { SimulationMetrics } from '../../src/simulation/types'
+
+const METRICS: SimulationMetrics = {
+  simulatedDate: new Date('2026-03-30T08:00:00.000Z'),
+  shipSpeedKmPerSecond: 42.4,
+  heliocentricDistanceAu: 1.04,
+  currentTargetDistanceAu: 2.03,
+  plannedDistanceAu: 2.08,
+  plannerStatus: 'future-intercept',
+  autonomousPhase: 'braking',
+  targetBearingDeg: 12.5,
+  etaDays: 14.5,
+  interceptTimeSeconds: 604_800,
+  targetMotionDuringInterceptAu: 0.004,
+}
+
+describe('MetricsPanel', () => {
+  it('renders autonomous travel status and paused simulation controls', () => {
+    render(
+      <MetricsPanel
+        metrics={METRICS}
+        onFasterTime={vi.fn()}
+        onPauseToggle={vi.fn()}
+        onSlowerTime={vi.fn()}
+        timeWarpDaysPerSecond={0}
+      />,
+    )
+
+    expect(screen.getByText('Travel status')).toBeInTheDocument()
+    expect(screen.getByText('Braking')).toBeInTheDocument()
+    expect(screen.getByText('Future intercept')).toBeInTheDocument()
+    expect(screen.getByText('paused')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Resume sim' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -21,8 +21,13 @@ function StubScene({
         selectedLocationId === 'pluto'
           ? 'future-intercept'
           : 'current-position',
+      autonomousPhase:
+        selectedLocationId === 'pluto' ? 'cruising' : 'acquiring',
       targetBearingDeg: 45,
       etaDays: selectedLocationId === 'pluto' ? 365 : null,
+      interceptTimeSeconds:
+        selectedLocationId === 'pluto' ? 100 * 86_400 : null,
+      targetMotionDuringInterceptAu: selectedLocationId === 'pluto' ? 1.45 : 0,
     })
   }, [onMetricsChange, selectedLocationId])
 
@@ -39,12 +44,18 @@ describe('AppShell', () => {
     expect(screen.getByText('42.4 km/s')).toBeInTheDocument()
     expect(screen.getByText('2.03 AU')).toBeInTheDocument()
     expect(screen.getByText('2.08 AU')).toBeInTheDocument()
+    expect(screen.getByText('Acquiring course')).toBeInTheDocument()
 
-    await user.selectOptions(screen.getByLabelText('Destination'), 'pluto')
+    await user.selectOptions(
+      screen.getByLabelText('Current destination'),
+      'pluto',
+    )
 
     expect(screen.getByText('34.95 AU')).toBeInTheDocument()
     expect(screen.getByText('36.40 AU')).toBeInTheDocument()
     expect(screen.getByText('Future intercept')).toBeInTheDocument()
+    expect(screen.getByText('Cruising')).toBeInTheDocument()
+    expect(screen.getByText('100.0 d')).toBeInTheDocument()
     expect(screen.getByTestId('destination-select')).toHaveValue('pluto')
   })
 })

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -1,5 +1,7 @@
 import {
+  formatAutonomousPhase,
   formatDistanceAu,
+  formatDurationSeconds,
   formatShipSpeedKmPerSecond,
   formatTimeWarp,
   formatUtcDate,
@@ -31,5 +33,18 @@ describe('formatters', () => {
     expect(formatUtcDate(new Date('2026-03-29T12:00:00.000Z'))).toBe(
       'Sun, 29 Mar 2026 12:00:00 UTC',
     )
+  })
+
+  it('formats travel durations across short and long horizons', () => {
+    expect(formatDurationSeconds(45)).toBe('45 s')
+    expect(formatDurationSeconds(7_200)).toBe('2.0 h')
+    expect(formatDurationSeconds(14 * 86_400)).toBe('14.0 d')
+  })
+
+  it('formats autonomous guidance phases for the HUD', () => {
+    expect(formatAutonomousPhase('acquiring')).toBe('Acquiring course')
+    expect(formatAutonomousPhase('cruising')).toBe('Cruising')
+    expect(formatAutonomousPhase('braking')).toBe('Braking')
+    expect(formatAutonomousPhase('arrived')).toBe('Arrived')
   })
 })


### PR DESCRIPTION
## Summary
- add ADR 014 for the destination-driven navigation HUD
- refocus the main HUD around destination selection, autonomous state, planner status, and intercept/travel details
- add component and integration coverage for the new HUD behavior

## Verification
- npm test
- npm run lint
- npm run build

Closes #27