### PR TITLE
Align route visuals and telemetry with intercept planning

### DIFF
--- a/docs/ARCHITECTURE/technicaldecisions/015-planner-aware-route-visuals-and-telemetry.md
+++ b/docs/ARCHITECTURE/technicaldecisions/015-planner-aware-route-visuals-and-telemetry.md
@@ -1,0 +1,98 @@
+# ADR 015: Planner-aware route visuals and intercept telemetry
+
+- **Status:** Accepted
+- **Date:** 2026-03-30
+- **Related:** ADR 012 (transfer planner with intercept prediction and capability-aware inputs), ADR 013 (command-driven autonomous guidance for normal-play ship control), ADR 014 (destination-driven navigation HUD for autonomous travel)
+
+## Context
+
+The autonomous-navigation rewrite now computes richer route facts than the
+scene and HUD currently communicate:
+
+- the transfer planner resolves both the destination's current position and a
+  predicted future intercept position
+- the guidance layer steers toward the planner's aim point, not always the
+  destination's current marker
+- telemetry already reports planner status, ETA, and destination drift
+
+Even with those systems in place, the final player-facing pass was still
+missing one important piece of legibility:
+
+- the scene only showed one destination ring and one generic course line
+- future-intercept plans were therefore hard to distinguish from current-fix
+  plans at a glance
+- the HUD did not surface the predicted intercept fix time directly
+
+Issue #28 requires closing that gap so route visuals, telemetry, and tests all
+describe the same autonomous-navigation model.
+
+## Decision
+
+### 1. Route visuals must distinguish current destination position from planned intercept aim
+
+When the planner reports `future-intercept`, the scene should show:
+
+- the destination's current resolved position
+- the planner's predicted intercept fix
+- the ship-to-aim course line used by the guidance layer
+- a short tether between current destination position and predicted intercept
+  fix so destination drift is visible
+
+When the planner is using `current-position` or `no-solution`, the scene keeps a
+single destination marker and the drift tether stays hidden.
+
+This preserves the current lightweight scene style while making the planner's
+actual decision legible.
+
+### 2. The HUD should expose the intercept fix timestamp when it exists
+
+Planner telemetry already reports whether the ship is using a future intercept.
+The HUD should also surface the predicted intercept fix date when the planner
+has one. That gives the player a concrete answer to "when is the ship aiming to
+meet the moving destination?" without exposing low-level solver internals.
+
+If the planner does not have a future intercept, that field may remain hidden.
+
+### 3. Planner status copy should explain the overlay model in player language
+
+The destination panel should describe planner state in terms of the running
+trip:
+
+- current-fix plans steer toward the destination's live position
+- future-intercept plans lead the target and should explain the current-marker
+  versus intercept-marker split
+- fallback plans steer toward the current fix until a better intercept is
+  available
+
+This keeps the destination-first HUD aligned with the scene overlays.
+
+### 4. Add tests around the planner-aware overlay state and telemetry
+
+The final autonomous-navigation pass should add or update tests that verify:
+
+- future-intercept plans produce distinct visual state from current-fix plans
+- intercept telemetry is surfaced when present
+- component and integration coverage continues to describe autonomous travel
+  rather than manual-flight assumptions
+
+## Consequences
+
+### Positive
+
+- Scene overlays finally match the planner model rather than approximating it.
+- Players can tell the difference between "where the destination is now" and
+  "where the ship is aiming to meet it."
+- Telemetry becomes more actionable during long-haul autonomous trips.
+
+### Negative
+
+- The scene orchestration layer now manages a second marker and a second route
+  line.
+- The metrics contract grows slightly to include the intercept fix timestamp.
+
+## Follow-up
+
+- If the planner later supports higher-fidelity transfer solutions, keep the
+  same visual vocabulary of current position, intercept fix, and route state.
+- If debug/manual navigation tools return, keep their overlays visually
+  separate from the normal autonomous-travel presentation.

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -33,6 +33,7 @@ export function ControlPanel({
     ? getLocationParent(selectedLocation)
     : undefined
   const destinationGroups = groupDestinations(destinations)
+  const plannerNarrative = describePlannerState(metrics.plannerStatus)
 
   return (
     <Card className="pointer-events-auto border-white/10 bg-slate-950/55 p-4 shadow-[0_24px_60px_rgba(0,0,0,0.3)] backdrop-blur-xl">
@@ -109,6 +110,9 @@ export function ControlPanel({
               transition between course acquisition, cruise, braking, and
               arrival without manual steering prompts.
             </p>
+            <p className="mt-2 text-xs leading-5 text-cyan-100/75">
+              {plannerNarrative}
+            </p>
           </div>
         ) : null}
       </div>
@@ -143,4 +147,17 @@ function groupDestinations(destinations: readonly LocationDefinition[]) {
   }
 
   return Array.from(groups.entries())
+}
+
+function describePlannerState(
+  plannerStatus: SimulationMetrics['plannerStatus'],
+): string {
+  switch (plannerStatus) {
+    case 'current-position':
+      return "Route overlay is steering toward the destination's current resolved position."
+    case 'future-intercept':
+      return 'The cyan ring marks the destination now, and the amber marker shows the predicted intercept fix the ship is leading toward.'
+    case 'no-solution':
+      return 'The planner has fallen back to the current destination fix until it can recover a better intercept solution.'
+  }
 }

--- a/src/components/MetricsPanel.tsx
+++ b/src/components/MetricsPanel.tsx
@@ -4,6 +4,7 @@ import {
   formatDurationSeconds,
   formatEtaDays,
   formatShipSpeedKmPerSecond,
+  formatShortUtcDate,
   formatTimeWarp,
   formatTransferPlannerStatus,
   formatUtcDate,
@@ -77,6 +78,13 @@ export function MetricsPanel({
           label="Intercept window"
           value={formatDurationSeconds(metrics.interceptTimeSeconds)}
         />
+        {metrics.interceptDate ? (
+          <MetricCell
+            className="col-span-2"
+            label="Intercept fix"
+            value={formatShortUtcDate(metrics.interceptDate)}
+          />
+        ) : null}
         <MetricCell
           label="Target drift"
           value={formatDistanceAu(metrics.targetMotionDuringInterceptAu)}

--- a/src/components/SimulatorCanvas.tsx
+++ b/src/components/SimulatorCanvas.tsx
@@ -9,6 +9,7 @@ import { useShipPhysics } from '../hooks/useShipPhysics'
 import { useSimulationMetrics } from '../hooks/useSimulationMetrics'
 import { useTimeSimulation } from '../hooks/useTimeSimulation'
 import { SceneBackground } from '../scene/SceneBackground'
+import { buildNavigationVisualState } from '../scene/navigation-visuals'
 import { ShipMesh } from '../scene/ShipMesh'
 import { SolarBodies } from '../scene/SolarBodies'
 import { SunMesh } from '../scene/SunMesh'
@@ -45,8 +46,10 @@ function SceneContents({
   const { report } = useSimulationMetrics(onMetricsChange)
 
   // Refs shared across hooks and the orchestrator frame
-  const targetMarkerRef = useRef<Mesh>(null)
+  const destinationMarkerRef = useRef<Mesh>(null)
+  const interceptMarkerRef = useRef<Mesh>(null)
   const trajectoryLineRef = useRef<Line>(null)
+  const interceptLineRef = useRef<Line>(null)
   const selectedLocationIdRef = useRef(selectedLocationId)
 
   useEffect(() => {
@@ -72,31 +75,46 @@ function SceneContents({
   useFrame((state, delta) => {
     const realDelta = Math.min(delta, 0.05)
     const plan = plannerResultRef.current
+    const visuals = buildNavigationVisualState(plan)
     const selectedLocation = getLocationById(plan.destinationId)
-
-    targetMarkerRef.current?.position.copy(plan.destination.currentPosition)
-    targetMarkerRef.current?.lookAt(state.camera.position)
-    targetMarkerRef.current?.scale.setScalar(
+    const markerScale =
       (selectedLocation
         ? getLocationMarkerScaleAu(selectedLocation.id)
-        : SUN.displayRadiusAu) * 7,
-    )
+        : SUN.displayRadiusAu) * 7
+
+    destinationMarkerRef.current?.position.copy(visuals.destinationPosition)
+    destinationMarkerRef.current?.lookAt(state.camera.position)
+    destinationMarkerRef.current?.scale.setScalar(markerScale)
+
+    if (interceptMarkerRef.current) {
+      interceptMarkerRef.current.visible = visuals.showInterceptMarker
+
+      if (visuals.interceptPosition) {
+        interceptMarkerRef.current.position.copy(visuals.interceptPosition)
+        interceptMarkerRef.current.lookAt(state.camera.position)
+        interceptMarkerRef.current.scale.setScalar(markerScale * 0.72)
+      }
+    }
 
     const shipState = shipStateRef.current
 
     // Update course line endpoints
     const line = trajectoryLineRef.current
     if (line) {
-      const posAttr = line.geometry.attributes.position
-      const arr = posAttr.array as Float32Array
-      arr[0] = shipState.position.x
-      arr[1] = shipState.position.y
-      arr[2] = shipState.position.z
-      arr[3] = plan.guidance.aimPosition.x
-      arr[4] = plan.guidance.aimPosition.y
-      arr[5] = plan.guidance.aimPosition.z
-      posAttr.needsUpdate = true
-      line.geometry.computeBoundingSphere()
+      updateLineEndpoints(line, shipState.position, visuals.aimPosition)
+    }
+
+    const interceptLine = interceptLineRef.current
+    if (interceptLine) {
+      interceptLine.visible = visuals.showInterceptMarker
+
+      if (visuals.interceptPosition) {
+        updateLineEndpoints(
+          interceptLine,
+          visuals.destinationPosition,
+          visuals.interceptPosition,
+        )
+      }
     }
 
     report(
@@ -114,8 +132,20 @@ function SceneContents({
       <SceneBackground />
       <SunMesh />
       <SolarBodies bodyMeshRefs={bodyMeshRefs} orbitEpoch={orbitEpoch} />
-      <TargetMarker targetRef={targetMarkerRef} />
+      <TargetMarker targetRef={destinationMarkerRef} />
+      <TargetMarker
+        color="#f7c77a"
+        innerRadius={0.08}
+        opacity={0.94}
+        outerRadius={0.12}
+        targetRef={interceptMarkerRef}
+      />
       <TrajectoryLine lineRef={trajectoryLineRef} />
+      <TrajectoryLine
+        color="#f7c77a"
+        lineRef={interceptLineRef}
+        opacity={0.38}
+      />
       <ShipMesh ref={shipRef} />
     </>
   )
@@ -147,3 +177,21 @@ export function SimulatorCanvas(props: SimulatorCanvasProps) {
 
 // Default export enables React.lazy(() => import('./SimulatorCanvas')) in App.tsx.
 export default SimulatorCanvas
+
+function updateLineEndpoints(
+  line: Line,
+  start: { x: number; y: number; z: number },
+  end: { x: number; y: number; z: number },
+) {
+  const posAttr = line.geometry.attributes.position
+  const arr = posAttr.array as Float32Array
+
+  arr[0] = start.x
+  arr[1] = start.y
+  arr[2] = start.z
+  arr[3] = end.x
+  arr[4] = end.y
+  arr[5] = end.z
+  posAttr.needsUpdate = true
+  line.geometry.computeBoundingSphere()
+}

--- a/src/hooks/useSimulationMetrics.ts
+++ b/src/hooks/useSimulationMetrics.ts
@@ -53,6 +53,12 @@ export function useSimulationMetrics(
           targetBearingDeg: plannerResult.guidance.bearingAngleDeg,
           etaDays: plannerResult.travel.etaDays,
           interceptTimeSeconds: plannerResult.travel.interceptTimeSeconds,
+          interceptDate:
+            plannerResult.status === 'future-intercept'
+              ? plannerResult.destination.predictedDate
+                ? new Date(plannerResult.destination.predictedDate)
+                : null
+              : null,
           targetMotionDuringInterceptAu:
             plannerResult.travel.targetMotionDuringInterceptAu,
         })

--- a/src/scene/TargetMarker.tsx
+++ b/src/scene/TargetMarker.tsx
@@ -2,6 +2,10 @@ import { DoubleSide, Mesh } from 'three'
 
 type TargetMarkerProps = {
   targetRef: React.RefObject<Mesh | null>
+  color?: string
+  innerRadius?: number
+  outerRadius?: number
+  opacity?: number
 }
 
 /**
@@ -9,13 +13,19 @@ type TargetMarkerProps = {
  * Position, orientation, and scale are driven imperatively each frame by
  * the scene orchestrator via `targetRef`.
  */
-export function TargetMarker({ targetRef }: TargetMarkerProps) {
+export function TargetMarker({
+  targetRef,
+  color = '#9fe0ff',
+  innerRadius = 0.12,
+  outerRadius = 0.16,
+  opacity = 0.86,
+}: TargetMarkerProps) {
   return (
     <mesh ref={targetRef}>
-      <ringGeometry args={[0.12, 0.16, 64]} />
+      <ringGeometry args={[innerRadius, outerRadius, 64]} />
       <meshBasicMaterial
-        color="#9fe0ff"
-        opacity={0.86}
+        color={color}
+        opacity={opacity}
         side={DoubleSide}
         transparent
       />

--- a/src/scene/TrajectoryLine.tsx
+++ b/src/scene/TrajectoryLine.tsx
@@ -2,6 +2,8 @@ import type { Line } from 'three'
 
 type TrajectoryLineProps = {
   lineRef: React.RefObject<Line | null>
+  color?: string
+  opacity?: number
 }
 
 /**
@@ -9,7 +11,11 @@ type TrajectoryLineProps = {
  * point. The two endpoint positions are driven imperatively each frame by the
  * scene orchestrator via the forwarded `lineRef`.
  */
-export function TrajectoryLine({ lineRef }: TrajectoryLineProps) {
+export function TrajectoryLine({
+  lineRef,
+  color = '#9fe0ff',
+  opacity = 0.45,
+}: TrajectoryLineProps) {
   return (
     <line ref={lineRef as unknown as React.Ref<SVGLineElement>}>
       <bufferGeometry>
@@ -18,7 +24,7 @@ export function TrajectoryLine({ lineRef }: TrajectoryLineProps) {
           attach="attributes-position"
         />
       </bufferGeometry>
-      <lineBasicMaterial color="#9fe0ff" opacity={0.45} transparent />
+      <lineBasicMaterial color={color} opacity={opacity} transparent />
     </line>
   )
 }

--- a/src/scene/navigation-visuals.ts
+++ b/src/scene/navigation-visuals.ts
@@ -1,0 +1,31 @@
+import type { TransferPlannerResult } from '../simulation/transfer-planner'
+
+const INTERCEPT_VISUAL_EPSILON_AU = 1e-6
+
+export type NavigationVisualState = {
+  destinationPosition: TransferPlannerResult['destination']['currentPosition']
+  aimPosition: TransferPlannerResult['guidance']['aimPosition']
+  interceptPosition:
+    | TransferPlannerResult['destination']['predictedPosition']
+    | null
+  showInterceptMarker: boolean
+}
+
+export function buildNavigationVisualState(
+  plannerResult: TransferPlannerResult,
+): NavigationVisualState {
+  const destinationPosition = plannerResult.destination.currentPosition.clone()
+  const aimPosition = plannerResult.guidance.aimPosition.clone()
+  const predictedPosition = plannerResult.destination.predictedPosition.clone()
+  const showInterceptMarker =
+    plannerResult.status === 'future-intercept' &&
+    destinationPosition.distanceTo(predictedPosition) >
+      INTERCEPT_VISUAL_EPSILON_AU
+
+  return {
+    destinationPosition,
+    aimPosition,
+    interceptPosition: showInterceptMarker ? predictedPosition : null,
+    showInterceptMarker,
+  }
+}

--- a/src/simulation/formatters.ts
+++ b/src/simulation/formatters.ts
@@ -30,6 +30,10 @@ export function formatUtcDate(date: Date): string {
   return date.toUTCString().replace('GMT', 'UTC')
 }
 
+export function formatShortUtcDate(date: Date): string {
+  return date.toUTCString().replace(/:\d{2} GMT$/, ' UTC')
+}
+
 /**
  * Formats an ETA expressed in days into a human-readable string.
  * Returns an em-dash when the ship is stationary (etaDays is null).

--- a/src/simulation/types.ts
+++ b/src/simulation/types.ts
@@ -17,6 +17,8 @@ export type SimulationMetrics = {
   etaDays: number | null
   /** Planned time-to-intercept for the current route solution. */
   interceptTimeSeconds: number | null
+  /** UTC timestamp for the predicted intercept fix when one exists. */
+  interceptDate: Date | null
   /** Expected destination motion between the current fix and intercept aim point. */
   targetMotionDuringInterceptAu: number
 }
@@ -36,5 +38,6 @@ export const INITIAL_METRICS: SimulationMetrics = {
   targetBearingDeg: 0,
   etaDays: null,
   interceptTimeSeconds: null,
+  interceptDate: null,
   targetMotionDuringInterceptAu: 0,
 }

--- a/tests/component/ControlPanel.test.tsx
+++ b/tests/component/ControlPanel.test.tsx
@@ -49,5 +49,10 @@ describe('ControlPanel', () => {
     expect(screen.getByText('Destination-driven bridge')).toBeInTheDocument()
     expect(screen.getByText('Autonomy: Acquiring course')).toBeInTheDocument()
     expect(screen.getByText('Planner: Future intercept')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'The cyan ring marks the destination now, and the amber marker shows the predicted intercept fix the ship is leading toward.',
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/component/MetricsPanel.test.tsx
+++ b/tests/component/MetricsPanel.test.tsx
@@ -15,6 +15,7 @@ const METRICS: SimulationMetrics = {
   targetBearingDeg: 12.5,
   etaDays: 14.5,
   interceptTimeSeconds: 604_800,
+  interceptDate: new Date('2026-04-06T08:00:00.000Z'),
   targetMotionDuringInterceptAu: 0.004,
 }
 
@@ -33,6 +34,7 @@ describe('MetricsPanel', () => {
     expect(screen.getByText('Travel status')).toBeInTheDocument()
     expect(screen.getByText('Braking')).toBeInTheDocument()
     expect(screen.getByText('Future intercept')).toBeInTheDocument()
+    expect(screen.getByText('Mon, 06 Apr 2026 08:00 UTC')).toBeInTheDocument()
     expect(screen.getByText('paused')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Resume sim' }),

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -27,6 +27,10 @@ function StubScene({
       etaDays: selectedLocationId === 'pluto' ? 365 : null,
       interceptTimeSeconds:
         selectedLocationId === 'pluto' ? 100 * 86_400 : null,
+      interceptDate:
+        selectedLocationId === 'pluto'
+          ? new Date('2026-07-07T12:00:00.000Z')
+          : null,
       targetMotionDuringInterceptAu: selectedLocationId === 'pluto' ? 1.45 : 0,
     })
   }, [onMetricsChange, selectedLocationId])
@@ -56,6 +60,7 @@ describe('AppShell', () => {
     expect(screen.getByText('Future intercept')).toBeInTheDocument()
     expect(screen.getByText('Cruising')).toBeInTheDocument()
     expect(screen.getByText('100.0 d')).toBeInTheDocument()
+    expect(screen.getByText('Tue, 07 Jul 2026 12:00 UTC')).toBeInTheDocument()
     expect(screen.getByTestId('destination-select')).toHaveValue('pluto')
   })
 })

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -3,6 +3,7 @@ import {
   formatDistanceAu,
   formatDurationSeconds,
   formatShipSpeedKmPerSecond,
+  formatShortUtcDate,
   formatTimeWarp,
   formatUtcDate,
 } from '../../src/simulation/formatters'
@@ -32,6 +33,12 @@ describe('formatters', () => {
   it('formats UTC dates consistently', () => {
     expect(formatUtcDate(new Date('2026-03-29T12:00:00.000Z'))).toBe(
       'Sun, 29 Mar 2026 12:00:00 UTC',
+    )
+  })
+
+  it('formats compact UTC dates for intercept-fix telemetry', () => {
+    expect(formatShortUtcDate(new Date('2026-03-29T12:00:00.000Z'))).toBe(
+      'Sun, 29 Mar 2026 12:00 UTC',
     )
   })
 

--- a/tests/unit/navigation-visuals.test.ts
+++ b/tests/unit/navigation-visuals.test.ts
@@ -1,0 +1,75 @@
+import { Vector3 } from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { buildNavigationVisualState } from '../../src/scene/navigation-visuals'
+import type { TransferPlannerResult } from '../../src/simulation/transfer-planner'
+
+describe('buildNavigationVisualState', () => {
+  it('shows a separate intercept marker for future-intercept plans', () => {
+    const state = buildNavigationVisualState(
+      createPlan({
+        currentPosition: new Vector3(10, 0, 0),
+        predictedPosition: new Vector3(12, 1, 0),
+        status: 'future-intercept',
+      }),
+    )
+
+    expect(state.showInterceptMarker).toBe(true)
+    expect(state.interceptPosition?.toArray()).toEqual([12, 1, 0])
+  })
+
+  it('hides the intercept marker when the planner is using the current fix', () => {
+    const state = buildNavigationVisualState(
+      createPlan({
+        currentPosition: new Vector3(10, 0, 0),
+        predictedPosition: new Vector3(10, 0, 0),
+        status: 'current-position',
+      }),
+    )
+
+    expect(state.showInterceptMarker).toBe(false)
+    expect(state.interceptPosition).toBeNull()
+  })
+})
+
+function createPlan({
+  currentPosition,
+  predictedPosition,
+  status,
+}: {
+  currentPosition: Vector3
+  predictedPosition: Vector3
+  status: TransferPlannerResult['status']
+}): TransferPlannerResult {
+  return {
+    destinationId: 'target',
+    status,
+    destination: {
+      currentPosition,
+      predictedPosition,
+      predictedDate:
+        status === 'future-intercept'
+          ? new Date('2026-04-01T12:00:00.000Z')
+          : null,
+      estimatedVelocityAuPerSec: new Vector3(0, 0, 0),
+    },
+    guidance: {
+      aimPosition: predictedPosition.clone(),
+      direction: new Vector3(1, 0, 0),
+      bearingAngleDeg: 0,
+    },
+    travel: {
+      currentDistanceAu: 1,
+      plannedDistanceAu: 1,
+      etaDays: 1,
+      interceptTimeSeconds: 86_400,
+      targetMotionDuringInterceptAu:
+        currentPosition.distanceTo(predictedPosition),
+      planningSpeedAuPerSec: 1e-5,
+    },
+    solver: {
+      iterations: 2,
+      solutionErrorSeconds: 0.1,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add ADR 015 for planner-aware route visuals and intercept telemetry
- distinguish current destination position from predicted intercept fixes in the scene overlays
- surface intercept-fix timing and planner-state explanations in the HUD, with regression coverage

## Testing
- npm run lint
- npm test
- npm run build

Closes #28
Closes #21