### PR TITLE
Fix stale returned ship orientation in physics step

### DIFF
--- a/src/simulation/physics.ts
+++ b/src/simulation/physics.ts
@@ -135,7 +135,7 @@ export function stepShipPhysics(
   deltaSec: number,
 ): ShipOrientation {
   const controls = normalizeShipControls(controlsOrKeys)
-  const { quaternion, forward, right, up } = getShipOrientationFromAngles(
+  const { forward, right, up } = getShipOrientationFromAngles(
     state.yaw,
     state.pitch,
   )
@@ -198,7 +198,7 @@ export function stepShipPhysics(
 
   state.position.addScaledVector(state.velocity, deltaSec)
 
-  return { quaternion, forward, right, up }
+  return getShipOrientationFromAngles(state.yaw, state.pitch)
 }
 
 function normalizeShipControls(

--- a/tests/unit/physics.test.ts
+++ b/tests/unit/physics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   createInitialShipState,
+  getShipOrientationFromAngles,
   PITCH_LIMIT_RAD,
   stepShipPhysics,
 } from '../../src/simulation/physics'
@@ -194,6 +195,19 @@ describe('stepShipPhysics', () => {
 
     // yaw should have increased by ~0.5 radians
     expect(state.yaw).toBeCloseTo(initialYaw + 0.5, 5)
+  })
+
+  it('returns the post-integration orientation after rotation updates', () => {
+    const state = createInitialShipState()
+    state.rotationAssist = false
+
+    const result = stepShipPhysics(state, new Set(['ArrowLeft']), 1.0)
+    const expected = getShipOrientationFromAngles(state.yaw, state.pitch)
+
+    expect(result.quaternion.angleTo(expected.quaternion)).toBeLessThan(1e-6)
+    expect(result.forward.distanceTo(expected.forward)).toBeLessThan(1e-6)
+    expect(result.right.distanceTo(expected.right)).toBeLessThan(1e-6)
+    expect(result.up.distanceTo(expected.up)).toBeLessThan(1e-6)
   })
 
   it('pitch is clamped to PITCH_LIMIT_RAD when angular velocity would exceed it', () => {


### PR DESCRIPTION
## Summary
- return post-integration orientation from `stepShipPhysics` while preserving start-of-frame axes for thrust integration
- add a regression test covering the returned orientation contract after rotation updates
- close the one-frame visual/control lag tracked in `stepShipPhysics`

Closes #38

## Test Plan
- [x] `vitest run tests/unit/physics.test.ts`
- [x] `vitest run`
- [x] `npm run lint`
- [x] `npm run build`
