### PR TITLE
fix: allow advancing to a new contract after a freight delivery

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/006-missions-cargo-and-freight-contracts.md
+++ b/docs/ARCHITECTURE/gamedecisions/006-missions-cargo-and-freight-contracts.md
@@ -64,6 +64,33 @@ available → active → completed
 
 Only one contract may be active at a time in v1 to keep state simple.
 
+#### Completion does not lock the board
+
+Reaching `completed` (or `failed`) for the active contract must not block the
+player from picking a different contract off the freight board. The board
+remains interactive in those terminal states, and a successful delivery simply
+returns the completed contract to the available set.
+
+Concretely, a contract row shows an **Accept contract** button when:
+
+- the active mission id is `null` (nothing in flight), **or**
+- the active mission is no longer in the `active` state (`completed` or
+  `failed`) — in which case the player may accept any contract, including a
+  different one. Accepting a new contract replaces the active id and resets
+  `missionStatus` to `active`, which dismisses the completion banner.
+
+This is what the user sees after a delivery:
+
+1. The completed contract's row is marked **Delivered ✓**.
+2. The completion banner at the top of the panel is still visible so the
+   player can read the reward summary.
+3. Every other contract row exposes an **Accept contract** button, and
+   clicking one advances the game onto the next haul without reloading.
+
+The active contract row itself does not show an Accept button while it is in
+the `active` state; that row is hidden from the board while the ship is
+working on it.
+
 ### 3. Arrival detection hooks into the autonomous guidance phase
 
 The autonomous guidance stack already exposes an `autonomousPhase` value that
@@ -82,11 +109,11 @@ adding a separate proximity sensor or a new physics pass.
 The first pass ships a small hard-coded catalog of at least three contracts
 spread across the freight network:
 
-| Contract | Origin | Destination |
-|---|---|---|
-| Mars Supply Run | Earth Orbit Freight Ring | Mars High Port |
-| Jovian Outpost Resupply | Ganymede Transfer Yard | Callisto Freight Depot |
-| Lunar Logistics Delivery | Cislunar Transfer Station | Luna Logistics Base |
+| Contract                 | Origin                    | Destination            |
+| ------------------------ | ------------------------- | ---------------------- |
+| Mars Supply Run          | Earth Orbit Freight Ring  | Mars High Port         |
+| Jovian Outpost Resupply  | Ganymede Transfer Yard    | Callisto Freight Depot |
+| Lunar Logistics Delivery | Cislunar Transfer Station | Luna Logistics Base    |
 
 This covers the Earth sphere, the Mars sphere, and the Jovian support network
 defined in ADR 005, keeping the first mission pass from being content-heavy

--- a/src/components/MissionsPanel.tsx
+++ b/src/components/MissionsPanel.tsx
@@ -73,8 +73,13 @@ export function MissionsPanel({
           const isDone =
             isActive &&
             (missionStatus === 'completed' || missionStatus === 'failed')
-          const canAccept =
-            activeMissionId === null || (isActive && missionStatus !== 'active')
+          // The board is locked only while a contract is in flight. Once the
+          // active contract reaches a terminal state (completed/failed) the
+          // player must be able to pick a *different* contract off the board
+          // without reloading, so any row becomes acceptable again.
+          const isBoardLocked =
+            activeMissionId !== null && missionStatus === 'active'
+          const canAccept = !isBoardLocked && !isActive
 
           if (isActive && missionStatus === 'active') return null
 

--- a/tests/component/MissionsPanel.test.tsx
+++ b/tests/component/MissionsPanel.test.tsx
@@ -36,9 +36,7 @@ describe('MissionsPanel', () => {
       />,
     )
 
-    screen
-      .getByTestId('accept-mission-mars-supply-run')
-      .click()
+    screen.getByTestId('accept-mission-mars-supply-run').click()
 
     expect(onAcceptMission).toHaveBeenCalledWith('mars-supply-run')
   })
@@ -75,5 +73,87 @@ describe('MissionsPanel', () => {
 
     expect(screen.getByText('Delivery complete')).toBeInTheDocument()
     expect(screen.getByText('+4,200 credits')).toBeInTheDocument()
+  })
+
+  it('allows accepting a different contract after the active one completes', () => {
+    // After delivery the active contract is in 'completed' state, but other
+    // contracts on the board must still be accept-able so the player can
+    // advance to the next haul (regression test for issue #39).
+    render(
+      <MissionsPanel
+        activeMissionId="mars-supply-run"
+        missionStatus="completed"
+        missions={missions}
+        onAcceptMission={vi.fn()}
+      />,
+    )
+
+    // The completed contract is marked as delivered and no longer exposes an
+    // accept button — the player should pick a different contract.
+    expect(screen.getByText('Delivered ✓')).toBeInTheDocument()
+    expect(screen.queryByTestId('accept-mission-mars-supply-run')).toBeNull()
+
+    // Other contracts on the board must be selectable.
+    expect(
+      screen.getByTestId('accept-mission-jovian-outpost-resupply'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('accept-mission-lunar-logistics-delivery'),
+    ).toBeInTheDocument()
+  })
+
+  it('invokes onAcceptMission with the new contract id after completion', () => {
+    const onAcceptMission = vi.fn()
+
+    render(
+      <MissionsPanel
+        activeMissionId="mars-supply-run"
+        missionStatus="completed"
+        missions={missions}
+        onAcceptMission={onAcceptMission}
+      />,
+    )
+
+    screen.getByTestId('accept-mission-jovian-outpost-resupply').click()
+
+    expect(onAcceptMission).toHaveBeenCalledWith('jovian-outpost-resupply')
+  })
+
+  it('locks the board only while a contract is in flight', () => {
+    // While the active contract is in the 'active' state every other contract
+    // on the board must remain locked — that part of the previous behavior is
+    // preserved.
+    const { rerender } = render(
+      <MissionsPanel
+        activeMissionId="mars-supply-run"
+        missionStatus="active"
+        missions={missions}
+        onAcceptMission={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.queryByTestId('accept-mission-jovian-outpost-resupply'),
+    ).toBeNull()
+    expect(
+      screen.queryByTestId('accept-mission-lunar-logistics-delivery'),
+    ).toBeNull()
+
+    // Once the active mission moves to a terminal state, the board unlocks.
+    rerender(
+      <MissionsPanel
+        activeMissionId="mars-supply-run"
+        missionStatus="failed"
+        missions={missions}
+        onAcceptMission={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('accept-mission-jovian-outpost-resupply'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('accept-mission-lunar-logistics-delivery'),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { useEffect } from 'react'
+import { act, useEffect } from 'react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
@@ -62,5 +62,103 @@ describe('AppShell', () => {
     expect(screen.getByText('100.0 d')).toBeInTheDocument()
     expect(screen.getByText('Tue, 07 Jul 2026 12:00 UTC')).toBeInTheDocument()
     expect(screen.getByTestId('destination-select')).toHaveValue('pluto')
+  })
+
+  it('lets the player advance to a different contract after delivery', async () => {
+    // Regression test for issue #39: after the active contract is marked
+    // completed, the player must be able to accept a *different* contract
+    // off the freight board without reloading the app.
+
+    type Metrics = Parameters<
+      NonNullable<SimulatorCanvasProps['onMetricsChange']>
+    >[0]
+
+    let pushMetrics: ((metrics: Metrics) => void) | null = null
+    let lastDestination: string | null = null
+
+    function ControllableStubScene({
+      onMetricsChange,
+      selectedLocationId,
+    }: SimulatorCanvasProps) {
+      pushMetrics = onMetricsChange
+      lastDestination = selectedLocationId
+      return <div data-testid="stub-scene" />
+    }
+
+    const user = userEvent.setup()
+    render(<AppShell SceneComponent={ControllableStubScene} />)
+
+    // Drive initial metrics so the App is fully wired up.
+    act(() => {
+      pushMetrics?.({
+        simulatedDate: new Date('2026-03-29T12:00:00.000Z'),
+        shipSpeedKmPerSecond: 42.4,
+        heliocentricDistanceAu: 1.04,
+        currentTargetDistanceAu: 0.5,
+        plannedDistanceAu: 0.5,
+        plannerStatus: 'current-position',
+        autonomousPhase: 'acquiring',
+        targetBearingDeg: 0,
+        etaDays: null,
+        interceptTimeSeconds: null,
+        interceptDate: null,
+        targetMotionDuringInterceptAu: 0,
+      })
+    })
+
+    // Select the mission's destination so the completion check in App matches.
+    await user.selectOptions(
+      screen.getByLabelText('Current destination'),
+      'mars-high-port',
+    )
+    expect(lastDestination).toBe('mars-high-port')
+
+    // 1. Accept the first contract.
+    await user.click(screen.getByTestId('accept-mission-mars-supply-run'))
+
+    // Active contract row is hidden, board is otherwise locked.
+    expect(
+      screen.queryByTestId('accept-mission-jovian-outpost-resupply'),
+    ).toBeNull()
+    expect(
+      screen.queryByTestId('accept-mission-lunar-logistics-delivery'),
+    ).toBeNull()
+
+    // 2. Simulate the autonomous guidance stack reporting 'arrived' at the
+    //    mission destination, which is what triggers completion in App.
+    act(() => {
+      pushMetrics?.({
+        simulatedDate: new Date('2026-04-12T12:00:00.000Z'),
+        shipSpeedKmPerSecond: 0,
+        heliocentricDistanceAu: 1.5,
+        currentTargetDistanceAu: 0,
+        plannedDistanceAu: 0,
+        plannerStatus: 'current-position',
+        autonomousPhase: 'arrived',
+        targetBearingDeg: 0,
+        etaDays: 0,
+        interceptTimeSeconds: 0,
+        interceptDate: new Date('2026-04-12T12:00:00.000Z'),
+        targetMotionDuringInterceptAu: 0,
+      })
+    })
+
+    // Completion banner appears, delivered mission is marked as done.
+    expect(screen.getByText('Delivery complete')).toBeInTheDocument()
+    expect(screen.getByText('Delivered ✓')).toBeInTheDocument()
+
+    // 3. The board unlocks and a *different* contract can be accepted.
+    const nextAccept = screen.getByTestId(
+      'accept-mission-jovian-outpost-resupply',
+    )
+    await user.click(nextAccept)
+
+    // The new contract is now active, the completion banner is gone, and the
+    // delivered mission remains on the board as a completed row.
+    expect(screen.getByText('Active contract')).toBeInTheDocument()
+    expect(screen.queryByText('Delivery complete')).toBeNull()
+    expect(
+      screen.queryByTestId('accept-mission-jovian-outpost-resupply'),
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
Closes #39.

## Summary

The mission board was effectively dead-ended after the first successful
delivery. The `MissionsPanel` accept-button logic only allowed re-accepting
the just-completed contract, locking the player out of the rest of the
freight board.

## Root cause

In `MissionsPanel.tsx`, the `canAccept` formula was:

```ts
const canAccept = activeMissionId === null || (isActive && missionStatus !== 'active')
```

After a delivery, `activeMissionId` was still the completed mission, so:
- other missions were not acceptable (`activeMissionId !== null` and
  `isActive === false`),
- the completed mission was acceptable again (`isActive === true` and
  `missionStatus !== 'active'`).

The mission loop dead-ended at the first successful delivery.

## Fix

Rework the board-lock predicate to gate on the active mission's status
instead of its mere presence:

```ts
const isBoardLocked = activeMissionId !== null && missionStatus === 'active'
const canAccept = !isBoardLocked && !isActive
```

The board now unlocks as soon as the active contract reaches a terminal
state (`completed`/`failed`), so the player can accept any other contract
on the freight board. The completed row stays in place showing the
**Delivered ✓** marker and no longer exposes its own accept button, so
the player is nudged to pick a new haul.

## ADR

Updated [ADR 006](../blob/fix/issue-39-mission-board-advance/docs/ARCHITECTURE/gamedecisions/006-missions-cargo-and-freight-contracts.md)
with the post-completion contract rule, per `AGENTS.md`.

## Tests

- `tests/component/MissionsPanel.test.tsx`
  - Completing the active contract unlocks the rest of the board.
  - The delivered row keeps its **Delivered ✓** marker and exposes no
    accept button.
  - The `onAcceptMission` callback fires with the new id.
  - The previous lock-while-active behavior is preserved (`rerender` to
    a terminal state unlocks the board).
- `tests/integration/App.test.tsx`
  - End-to-end: accept `mars-supply-run` → select its destination →
    simulate the autonomous guidance stack reporting `arrived` →
    delivery complete banner appears → accept `jovian-outpost-resupply`
    → completion banner disappears and the new contract is active.

## Verification

- `npm test` → 151/151 tests pass
- `npm run lint` → clean (`--max-warnings=0`)
- `npm run build` → clean (`tsc --noEmit && vite build`)
- Prettier: changes formatted